### PR TITLE
Update removeTrailingNewLine.js

### DIFF
--- a/packages/utils/src/removeTrailingNewLine.js
+++ b/packages/utils/src/removeTrailingNewLine.js
@@ -29,7 +29,7 @@ export const removeTrailingNewLine = (pdf) => {
     output = sliceLastChar(output, '\r');
 
     const lastLine = output.slice(output.length - 6).toString();
-    if (lastLine !== '\n%%EOF') {
+    if (lastLine !== '\n%%EOF' && lastLine !== '\r%%EOF') {
         throw new SignPdfError(
             'A PDF file must end with an EOF line.',
             SignPdfError.TYPE_PARSE,


### PR DESCRIPTION
Files that ends with '\r%%EOF' will no longer throw an error